### PR TITLE
Workaround to reading detector hits into root

### DIFF
--- a/include/Detector.hh
+++ b/include/Detector.hh
@@ -7,7 +7,9 @@
 #include "G4SystemOfUnits.hh"
 #include "G4AnalysisManager.hh"
 #include "G4RunManager.hh"
-
+//includes for CSV
+#include "g4csv_defs.hh"
+#include "G4CsvAnalysisManager.hh"
 
 
 class MySensitiveDetector : public G4VSensitiveDetector {

--- a/include/RunAction.hh
+++ b/include/RunAction.hh
@@ -5,6 +5,9 @@
 #include "G4AnalysisManager.hh" 
 #include "G4SystemOfUnits.hh"
 // #include "g4root.hh"
+//incudes for csv files
+#include "g4csv_defs.hh"
+#include "G4CsvAnalysisManager.hh"
 
 class MyRunAction : public G4UserRunAction {
     public:

--- a/src/Detector.cc
+++ b/src/Detector.cc
@@ -26,6 +26,10 @@ G4bool MySensitiveDetector::ProcessHits(G4Step *aStep, G4TouchableHistory *ROhis
     G4ThreeVector posPhoton = preStepPoint->GetPosition();
     //G4cout << "Photon Position: " << posPhoton << G4endl;
 
+    //variables for CSV ntuples
+    G4int trackID{ track->GetTrackID() };
+    G4int event{ G4RunManager::GetRunManager()->GetCurrentEvent()->GetEventID() };
+    track->SetTrackStatus(fStopAndKill);
     // ::::::::::::::::::::::::: Identify Creation Process of Photon: :::::::::::::::::::::::::::::::::::::::::::::::::
 
     if (aStep->GetTrack()->GetParticleDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) {
@@ -85,6 +89,14 @@ G4bool MySensitiveDetector::ProcessHits(G4Step *aStep, G4TouchableHistory *ROhis
     // Get position of detector:
     // G4VPhysicalVolume *physVol = touchable->GetVolume();
     // G4ThreeVector posDetector = physVol->GetTranslation();
+
+
+    // ::::::::::::::::::::::::: Read Sensitive Detector Hits into CSV Ntuples ::::::::::::::::::::::::::::::::::::::::::::::
+    G4CsvAnalysisManager* csvmanager{ G4CsvAnalysisManager::Instance() };
+    csvmanager->FillNtupleIColumn(0, event);
+    csvmanager->FillNtupleDColumn(1, trackID);
+    csvmanager->FillNtupleDColumn(2, edep);
+    csvmanager->AddNtupleRow(0);
     return true;
 }
 

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -22,6 +22,15 @@ void MyRunAction::BeginOfRunAction(const G4Run*) {
     manager->CreateNtupleDColumn("fZ");
     manager->FinishNtuple(0);
 */
+
+    //code for writing into csv file
+    auto csvmanager{ G4CsvAnalysisManager::Instance() };
+    csvmanager->OpenFile("output.csv");
+    csvmanager->CreateNtuple("Hits", "Hits");
+    csvmanager->CreateNtupleIColumn("fEvent");
+    csvmanager->CreateNtupleDColumn("trackID");
+    csvmanager->CreateNtupleDColumn("Energy");
+    csvmanager->FinishNtuple(0);
 }
 
 void MyRunAction::EndOfRunAction(const G4Run*) {
@@ -29,4 +38,9 @@ void MyRunAction::EndOfRunAction(const G4Run*) {
 
     manager->Write();
     manager->CloseFile();
+
+    //code for writing into csv file
+    auto csvmanager{ G4CsvAnalysisManager::Instance() };
+    csvmanager->Write();
+    csvmanager->CloseFile();
 }


### PR DESCRIPTION
Modifies code to read detector hits into a csv file using G4CsvAnalysisManager. 
Each csv file will have the event number, the track id of the photon depositing energy, and the energy deposited by the photon. 
Other parameters can be easily added.